### PR TITLE
Add support to configure enabled protocol value

### DIFF
--- a/src/IIS.Tests/Cake.IIS.Tests.csproj
+++ b/src/IIS.Tests/Cake.IIS.Tests.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Tests\ApplicationPoolTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Tests\BindingTests.cs" />
+    <Compile Include="Tests\ApplicationTests.cs" />
     <Compile Include="Tests\WebFarmTests.cs" />
     <Compile Include="Utils\DebugLog.cs" />
     <Compile Include="Utils\CakeHelper.cs" />

--- a/src/IIS.Tests/Tests/ApplicationTests.cs
+++ b/src/IIS.Tests/Tests/ApplicationTests.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Cake.IIS.Tests
+{
+    public class ApplicationTests
+    {
+        [Fact]
+        public void Should_Create_Application()
+        {
+            // Arrange
+            var websiteSettings = CakeHelper.GetWebsiteSettings();
+            CakeHelper.DeleteWebsite(websiteSettings.Name);
+            CakeHelper.CreateWebsite(websiteSettings);
+
+            var appSettings = CakeHelper.GetApplicationSettings(websiteSettings.Name);
+
+            // Act
+            WebsiteManager manager = CakeHelper.CreateWebsiteManager();
+            var added = manager.AddApplication(appSettings);
+
+            // Assert
+            Assert.True(added);
+            Assert.NotNull(CakeHelper.GetApplication(websiteSettings.Name, appSettings.ApplicationPath));
+        }
+
+        [Fact]
+        public void Should_Create_Application_With_Predefined_EnabledProtocols()
+        {
+            // Arrange
+            var websiteSettings = CakeHelper.GetWebsiteSettings();
+            CakeHelper.DeleteWebsite(websiteSettings.Name);
+            CakeHelper.CreateWebsite(websiteSettings);
+
+            var appSettings = CakeHelper.GetApplicationSettings(websiteSettings.Name);
+            appSettings.AlternateEnabledProtocols = "http,net.pipe";
+
+            // Act
+            WebsiteManager manager = CakeHelper.CreateWebsiteManager();
+            var added = manager.AddApplication(appSettings);
+
+            // Assert
+            Assert.True(added);
+            var application = CakeHelper.GetApplication(websiteSettings.Name, appSettings.ApplicationPath);
+            Assert.NotNull(application);
+            Assert.Contains(BindingProtocol.Http.ToString(), 
+                application.EnabledProtocols, 
+                StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(BindingProtocol.NetPipe.ToString(), 
+                application.EnabledProtocols, 
+                StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/IIS.Tests/Tests/WebsiteTests.cs
+++ b/src/IIS.Tests/Tests/WebsiteTests.cs
@@ -1,5 +1,8 @@
 ﻿#region Using Statements
-    using Microsoft.Web.Administration;
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Web.Administration;
     using Xunit;
 #endregion
 
@@ -91,7 +94,32 @@ namespace Cake.IIS.Tests
         }
 
         [Fact]
+        public void Should_Create_Website_With_Predefined_EnabledProtocols()
+        {
+            // Arrange
+            var settings = CakeHelper.GetWebsiteSettings();
+            settings.AlternateEnabledProtocols = "http,net.msmq,net.tcp";
+            CakeHelper.DeleteWebsite(settings.Name);
 
+            // Act
+            WebsiteManager manager = CakeHelper.CreateWebsiteManager();
+            manager.Create(settings);
+
+            // Assert
+            var website = CakeHelper.GetWebsite(settings.Name);
+            Assert.NotNull(website);
+            Assert.Contains(BindingProtocol.Http.ToString(), 
+                website.ApplicationDefaults.EnabledProtocols, 
+                StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(BindingProtocol.NetMsmq.ToString(), 
+                website.ApplicationDefaults.EnabledProtocols, 
+                StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(BindingProtocol.NetTcp.ToString(), 
+                website.ApplicationDefaults.EnabledProtocols, 
+                StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
         public void Should_Delete_Website()
         {
             // Arrange

--- a/src/IIS.Tests/Tests/WebsiteTests.cs
+++ b/src/IIS.Tests/Tests/WebsiteTests.cs
@@ -1,8 +1,6 @@
 ﻿#region Using Statements
-
-using System;
-using System.Collections.Generic;
-using Microsoft.Web.Administration;
+    using System;
+    using Microsoft.Web.Administration;
     using Xunit;
 #endregion
 

--- a/src/IIS.Tests/Utils/CakeHelper.cs
+++ b/src/IIS.Tests/Utils/CakeHelper.cs
@@ -108,6 +108,18 @@ namespace Cake.IIS.Tests
                 return settings;
             }
 
+            public static ApplicationSettings GetApplicationSettings(string siteName)
+            {
+                return new ApplicationSettings
+                {
+                    ApplicationPath = "/Test",
+                    ApplicationPool = CakeHelper.GetAppPoolSettings().Name,
+                    VirtualDirectory = "/",
+                    PhysicalDirectory = "./Test/App/",
+                    SiteName = siteName,
+                };
+            }
+
             public static WebFarmSettings GetWebFarmSettings()
             {
                 return new WebFarmSettings
@@ -145,7 +157,22 @@ namespace Cake.IIS.Tests
             {
                 using (var serverManager = new ServerManager())
                 {
-                    return serverManager.Sites.FirstOrDefault(x => x.Name == name);
+                    var site = serverManager.Sites.FirstOrDefault(x => x.Name == name);
+                    // Below is required to fetch ApplicationDefaults before disposing ServerManager.
+                    if (site != null && site.ApplicationDefaults != null)
+                    {
+                        return site;
+                    }
+                    return site;
+                }
+            }
+
+            public static Application GetApplication(string siteName, string appPath)
+            {
+                using (var serverManager = new ServerManager())
+                {
+                    var site = serverManager.Sites.FirstOrDefault(x => x.Name == siteName) ;
+                    return site != null ? site.Applications.FirstOrDefault(a => a.Path == appPath) : null;
                 }
             }
 

--- a/src/IIS/Manager/Base/BaseSiteManager.cs
+++ b/src/IIS/Manager/Base/BaseSiteManager.cs
@@ -2,6 +2,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Text;
     using System.Threading;
 
     using Cake.Core;
@@ -102,6 +103,12 @@ namespace Cake.IIS
                     settings.Binding.BindingProtocol.ToString().ToLower(),
                     settings.Binding.BindingInformation,
                     this.GetPhysicalDirectory(settings));
+
+                if (!String.IsNullOrEmpty(settings.AlternateEnabledProtocols))
+                {
+                    site.ApplicationDefaults.EnabledProtocols = settings.AlternateEnabledProtocols;
+                }
+
 
                 if (settings.Binding.CertificateHash != null)
                 {
@@ -515,6 +522,10 @@ namespace Cake.IIS
                         app.Path = settings.ApplicationPath;
                         app.ApplicationPoolName = settings.ApplicationPool;
 
+                        if (!String.IsNullOrEmpty(settings.AlternateEnabledProtocols))
+                        {
+                            app.EnabledProtocols = settings.AlternateEnabledProtocols;
+                        }
 
 
                         //Get Directory

--- a/src/IIS/Manager/Base/BaseSiteManager.cs
+++ b/src/IIS/Manager/Base/BaseSiteManager.cs
@@ -2,7 +2,6 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Text;
     using System.Threading;
 
     using Cake.Core;

--- a/src/IIS/Settings/ApplicationSettings.cs
+++ b/src/IIS/Settings/ApplicationSettings.cs
@@ -1,6 +1,5 @@
 #region Using Statements
     using System;
-    using System.Collections.Generic;
     using Cake.Core.IO;
 #endregion
 

--- a/src/IIS/Settings/ApplicationSettings.cs
+++ b/src/IIS/Settings/ApplicationSettings.cs
@@ -1,5 +1,6 @@
 #region Using Statements
     using System;
+    using System.Collections.Generic;
     using Cake.Core.IO;
 #endregion
 
@@ -47,6 +48,7 @@ namespace Cake.IIS
 
             public AuthorizationSettings Authorization { get; set; }
 
+            public string AlternateEnabledProtocols { get; set; }
 
 
             [Obsolete("Use Authentication.UserName")]

--- a/src/IIS/Settings/SiteSettings.cs
+++ b/src/IIS/Settings/SiteSettings.cs
@@ -1,4 +1,5 @@
 ﻿#region Using Statements
+    using System.Collections.Generic;
     using Cake.Core.IO;
 #endregion
 
@@ -35,6 +36,8 @@ namespace Cake.IIS
             public DirectoryPath PhysicalDirectory { get; set; }
 
             public BindingSettings Binding { get; set; }
+
+            public string AlternateEnabledProtocols { get; set; }
 
             public ApplicationPoolSettings ApplicationPool { get; set; }
 

--- a/src/IIS/Settings/SiteSettings.cs
+++ b/src/IIS/Settings/SiteSettings.cs
@@ -1,5 +1,4 @@
 ﻿#region Using Statements
-    using System.Collections.Generic;
     using Cake.Core.IO;
 #endregion
 


### PR DESCRIPTION
Added support to configure several protocols in Website and Application.
This is required to accept types of requests other than http.

I've decided to use Alternate prefix because EnabledProtocols has some default values and behaviors in IIS: [MSDN](https://msdn.microsoft.com/en-us/library/microsoft.web.administration.application.enabledprotocols.aspx)