### PR TITLE
Project would not compile because of a missing semicolon.

### DIFF
--- a/src/IIS/Bindings/BindingSettings.cs
+++ b/src/IIS/Bindings/BindingSettings.cs
@@ -24,7 +24,7 @@ namespace Cake.IIS
         {
             this.BindingProtocol = bindingProtocol;
 
-            IISBindings.Http.SetIpAddress("127.0.0.1").SetPort(8080)
+            IISBindings.Http.SetIpAddress("127.0.0.1").SetPort(8080);
         }
         #endregion
 


### PR DESCRIPTION
I pulled down a copy of your repo to look at the BindingSettings class and was able to compile the code due to this missing semicolon. its minor, but thought i would call it out.