### PR TITLE
Upgrade Cake to 0.17.0

### DIFF
--- a/src/IIS.Tests/Cake.IIS.Tests.csproj
+++ b/src/IIS.Tests/Cake.IIS.Tests.csproj
@@ -38,8 +38,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.6.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Core.0.6.4\lib\net45\Cake.Core.dll</HintPath>
+    <Reference Include="Cake.Core, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Web.Administration, Version=7.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/src/IIS.Tests/Utils/DebugLog.cs
+++ b/src/IIS.Tests/Utils/DebugLog.cs
@@ -28,6 +28,7 @@ namespace Cake.IIS.Tests
         public Verbosity Verbosity
         {
             get { return Verbosity.Diagnostic; }
+            set { }
         }
 
 

--- a/src/IIS.Tests/packages.config
+++ b/src/IIS.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.6.4" targetFramework="net45" />
+  <package id="Cake.Core" version="0.17.0" targetFramework="net45" />
   <package id="NSubstitute" version="1.9.2.0" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />

--- a/src/IIS/Cake.IIS.csproj
+++ b/src/IIS/Cake.IIS.csproj
@@ -33,8 +33,8 @@
     <DocumentationFile>bin\Release\Cake.IIS.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.6.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Core.0.6.4\lib\net45\Cake.Core.dll</HintPath>
+    <Reference Include="Cake.Core, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Web.Administration, Version=7.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/src/IIS/packages.config
+++ b/src/IIS/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.6.4" targetFramework="net45" />
+  <package id="Cake.Core" version="0.17.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Cake 0.18.0 will requires at least version 0.16.x to work.