### PR TITLE
Bug - setting authentication

### DIFF
--- a/src/IIS.Tests/Cake.IIS.Tests.csproj
+++ b/src/IIS.Tests/Cake.IIS.Tests.csproj
@@ -76,11 +76,13 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
+    <Compile Include="Tests\ApplicationAuthenticationTests.cs" />
     <Compile Include="Tests\ApplicationPoolTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Tests\BindingTests.cs" />
     <Compile Include="Tests\ApplicationTests.cs" />
     <Compile Include="Tests\WebFarmTests.cs" />
+    <Compile Include="Tests\WebsiteAuthenticationTests.cs" />
     <Compile Include="Utils\DebugLog.cs" />
     <Compile Include="Utils\CakeHelper.cs" />
     <Compile Include="Tests\WebsiteTests.cs" />

--- a/src/IIS.Tests/Tests/ApplicationAuthenticationTests.cs
+++ b/src/IIS.Tests/Tests/ApplicationAuthenticationTests.cs
@@ -1,0 +1,131 @@
+﻿#region Using Statements
+using System;
+using Xunit;
+#endregion
+
+
+namespace Cake.IIS.Tests.Tests
+{
+    public class ApplicationAuthenticationTests
+    {
+
+        [Theory]
+        [InlineData(true, false, true)]
+        [InlineData(false, true, false)]
+        public void Should_Set_Authentication(bool? anon, bool? basic, bool? win)
+        {
+            //Setup
+            var websiteName = "Batman";
+            CakeHelper.DeleteWebsite(websiteName);
+
+            // Arrange
+            var websiteSettings = CakeHelper.GetWebsiteSettings(websiteName);
+            CakeHelper.CreateWebsite(websiteSettings);
+
+            var appSettings = CakeHelper.GetApplicationSettings(websiteName);
+            appSettings.Authentication = CakeHelper.GetAuthenticationSettings(anon, basic, win);
+            EnsureDirectoryExist(appSettings.PhysicalDirectory.ToString());
+
+            // Act
+            WebsiteManager manager = CakeHelper.CreateWebsiteManager();
+            var added = manager.AddApplication(appSettings);
+
+            //Assert
+            Assert.True(added);
+            var authentication = CakeHelper.ReadAuthenticationSettings(websiteName, appSettings.ApplicationPath);
+
+            Assert.Equal(anon, authentication.EnableAnonymousAuthentication);
+            Assert.Equal(basic, authentication.EnableBasicAuthentication);
+            Assert.Equal(win, authentication.EnableWindowsAuthentication);
+
+            //Teardown
+            CakeHelper.DeleteWebsite(websiteName);
+        }
+
+        [Fact]
+        public void Should_Set_ApplicationAuthentication_Only()
+        {
+            //Setup
+            var websiteName = "Batman";
+            var serverAuth = CakeHelper.ReadAuthenticationSettings();
+            CakeHelper.DeleteWebsite(websiteName);
+
+            // Arrange
+            var websiteSettings = CakeHelper.GetWebsiteSettings(websiteName);
+            CakeHelper.CreateWebsite(websiteSettings);
+
+            var appSettings = CakeHelper.GetApplicationSettings(websiteName);
+            var appAuth = CakeHelper.GetAuthenticationSettings(
+                !serverAuth.EnableAnonymousAuthentication.Value,
+                !serverAuth.EnableBasicAuthentication.Value,
+                !serverAuth.EnableWindowsAuthentication.Value);// setting application-authenication opposite to server-level-authentication
+            appSettings.Authentication = appAuth;
+            EnsureDirectoryExist(appSettings.PhysicalDirectory.ToString());
+
+            // Act
+            WebsiteManager manager = CakeHelper.CreateWebsiteManager();
+            var added = manager.AddApplication(appSettings);
+
+            //Assert
+            Assert.True(added);
+            AssertAuthentication(CakeHelper.ReadAuthenticationSettings(), serverAuth);  //server Auth
+            AssertAuthentication(CakeHelper.ReadAuthenticationSettings(websiteName), serverAuth);  //website Auth
+            AssertAuthentication(CakeHelper.ReadAuthenticationSettings(websiteName, appSettings.ApplicationPath), appAuth);  //website Auth
+
+            //Teardown
+            CakeHelper.DeleteWebsite(websiteName);
+
+        }
+
+        [Fact]
+        public void Should_Only_Set_NotNull_Setting()
+        {
+            //Setup
+            var websiteName = "Batman";
+            CakeHelper.DeleteWebsite(websiteName);
+
+            // Arrange
+            var websiteSettings = CakeHelper.GetWebsiteSettings(websiteName);
+            var serverAuth = CakeHelper.ReadAuthenticationSettings();
+            CakeHelper.CreateWebsite(websiteSettings);
+
+            var anon = serverAuth.EnableAnonymousAuthentication.Value;
+            var basic = serverAuth.EnableBasicAuthentication.Value;
+            var win = serverAuth.EnableWindowsAuthentication.Value;
+
+
+
+            var appSettings = CakeHelper.GetApplicationSettings(websiteName);
+            appSettings.Authentication = CakeHelper.GetAuthenticationSettings(!anon, null, null);  //only resetting anonymous to inverse of default. 
+
+            WebsiteManager manager = CakeHelper.CreateWebsiteManager();
+            var added = manager.AddApplication(appSettings);
+
+            //Assert
+            var webAuth = CakeHelper.ReadAuthenticationSettings(websiteName);
+            var appAuth = CakeHelper.ReadAuthenticationSettings(websiteName, appSettings.ApplicationPath);
+
+            AssertAuthentication(serverAuth, webAuth);
+
+            Assert.Equal(!anon, appAuth.EnableAnonymousAuthentication);
+            Assert.Equal(basic, appAuth.EnableBasicAuthentication);
+            Assert.Equal(win, appAuth.EnableWindowsAuthentication);
+
+            //Teardown
+            CakeHelper.DeleteWebsite(websiteName);
+        }
+
+        private void EnsureDirectoryExist(string path)
+        {
+            if (!System.IO.Directory.Exists(path))
+                System.IO.Directory.CreateDirectory(path);
+        }
+
+        private void AssertAuthentication(AuthenticationSettings expected, AuthenticationSettings actual)
+        {
+            Assert.Equal(expected.EnableAnonymousAuthentication, actual.EnableAnonymousAuthentication.Value);
+            Assert.Equal(expected.EnableBasicAuthentication, actual.EnableBasicAuthentication.Value);
+            Assert.Equal(expected.EnableWindowsAuthentication, actual.EnableWindowsAuthentication.Value);
+        }
+    }
+}

--- a/src/IIS.Tests/Tests/ApplicationTests.cs
+++ b/src/IIS.Tests/Tests/ApplicationTests.cs
@@ -57,5 +57,37 @@ namespace Cake.IIS.Tests
 
             CakeHelper.DeleteWebsite(websiteSettings.Name);
         }
+
+        [Theory]
+        [InlineData(true,false,true)]
+        [InlineData(false,true,false)]
+        public void Should_Set_Authentication(bool annon,bool basic,bool win)
+        {
+
+            // Arrange
+            var websiteName = "Batman";
+            CakeHelper.DeleteWebsite(websiteName);
+            var websiteSettings = CakeHelper.GetWebsiteSettings(websiteName);
+            CakeHelper.CreateWebsite(websiteSettings);
+
+            var appSettings = CakeHelper.GetApplicationSettings(websiteName);
+
+            appSettings.Authentication = CakeHelper.GetAuthenticationSettings(annon, basic, win);
+
+            // Act
+            WebsiteManager manager = CakeHelper.CreateWebsiteManager();
+            var added = manager.AddApplication(appSettings);
+
+            //Assert
+            Assert.True(added);
+            var authentication = CakeHelper.ReadAuthenticationSettings(websiteName);
+
+            Assert.Equal(annon, authentication.EnableAnonymousAuthentication);
+            Assert.Equal(basic, authentication.EnableBasicAuthentication);
+            Assert.Equal(win, authentication.EnableWindowsAuthentication);
+
+            CakeHelper.DeleteWebsite(websiteName);
+
+        }
     }
 }

--- a/src/IIS.Tests/Tests/ApplicationTests.cs
+++ b/src/IIS.Tests/Tests/ApplicationTests.cs
@@ -156,7 +156,7 @@ namespace Cake.IIS.Tests
         {
             var path = websiteSettings.PhysicalDirectory.ToString();
             if(Directory.Exists(path))
-                Directory.Delete(path);
+                Directory.Delete(path, true);
 
             CakeHelper.DeleteWebsite(websiteSettings.Name);
         }

--- a/src/IIS.Tests/Tests/ApplicationTests.cs
+++ b/src/IIS.Tests/Tests/ApplicationTests.cs
@@ -1,7 +1,8 @@
 ﻿#region Using Statements
 using System;
-
+using System.Runtime.InteropServices;
 using Xunit;
+using System.IO;
 #endregion
 
 
@@ -127,8 +128,12 @@ namespace Cake.IIS.Tests
         [Fact]
         public void Should_Create_Application_Without_DirectoryBrowsing_In_Settings()
         {
-            // Arrange
+            //Setup
+            var websiteName = "Banner";
             var websiteSettings = CakeHelper.GetWebsiteSettings("Banner");
+            Cleanup(websiteSettings);
+
+            // Arrange
             var appSettings = CakeHelper.GetApplicationSettings(websiteSettings.Name);
             appSettings.EnableDirectoryBrowsing = false;
             // Make sure the web.config exists
@@ -142,6 +147,16 @@ namespace Cake.IIS.Tests
             // Assert
             var value = CakeHelper.GetWebConfigurationValue(websiteSettings.Name, appSettings.ApplicationPath, "system.webServer/directoryBrowse", "enabled");
             Assert.False((bool)value);
+
+            //Teardown
+            Cleanup(websiteSettings);
+        }
+
+        private void Cleanup(WebsiteSettings websiteSettings)
+        {
+            var path = websiteSettings.PhysicalDirectory.ToString();
+            if(Directory.Exists(path))
+                Directory.Delete(path);
 
             CakeHelper.DeleteWebsite(websiteSettings.Name);
         }

--- a/src/IIS.Tests/Tests/ApplicationTests.cs
+++ b/src/IIS.Tests/Tests/ApplicationTests.cs
@@ -57,37 +57,5 @@ namespace Cake.IIS.Tests
 
             CakeHelper.DeleteWebsite(websiteSettings.Name);
         }
-
-        [Theory]
-        [InlineData(true,false,true)]
-        [InlineData(false,true,false)]
-        public void Should_Set_Authentication(bool annon,bool basic,bool win)
-        {
-
-            // Arrange
-            var websiteName = "Batman";
-            CakeHelper.DeleteWebsite(websiteName);
-            var websiteSettings = CakeHelper.GetWebsiteSettings(websiteName);
-            CakeHelper.CreateWebsite(websiteSettings);
-
-            var appSettings = CakeHelper.GetApplicationSettings(websiteName);
-
-            appSettings.Authentication = CakeHelper.GetAuthenticationSettings(annon, basic, win);
-
-            // Act
-            WebsiteManager manager = CakeHelper.CreateWebsiteManager();
-            var added = manager.AddApplication(appSettings);
-
-            //Assert
-            Assert.True(added);
-            var authentication = CakeHelper.ReadAuthenticationSettings(websiteName);
-
-            Assert.Equal(annon, authentication.EnableAnonymousAuthentication);
-            Assert.Equal(basic, authentication.EnableBasicAuthentication);
-            Assert.Equal(win, authentication.EnableWindowsAuthentication);
-
-            CakeHelper.DeleteWebsite(websiteName);
-
-        }
     }
 }

--- a/src/IIS.Tests/Tests/WebsiteAuthenticationTests.cs
+++ b/src/IIS.Tests/Tests/WebsiteAuthenticationTests.cs
@@ -1,0 +1,35 @@
+﻿using Xunit;
+
+namespace Cake.IIS.Tests.Tests
+{
+    public class WebsiteAuthenticationTests
+    {
+        [Theory]
+        [InlineData(true, false, true)]
+        [InlineData(false, true, false)]
+        public void Should_Set_Authentication(bool anon, bool basic, bool win)
+        {
+            //Setup
+            var websiteName = "HumanTorch";
+            CakeHelper.DeleteWebsite(websiteName);
+
+            // Arrange
+            var settings = CakeHelper.GetWebsiteSettings(websiteName);
+            settings.Authentication = CakeHelper.GetAuthenticationSettings(anon, basic, win);
+
+            //Act
+            CakeHelper.CreateWebsite(settings);
+            CakeHelper.StartWebsite(websiteName);
+
+            //Assert
+            var authentication = CakeHelper.ReadAuthenticationSettings(websiteName);
+            Assert.Equal(anon, authentication.EnableAnonymousAuthentication);
+            Assert.Equal(basic, authentication.EnableBasicAuthentication);
+            Assert.Equal(win, authentication.EnableWindowsAuthentication);
+
+            //Teardown
+            CakeHelper.DeleteWebsite(websiteName);
+
+        }
+    }
+}

--- a/src/IIS.Tests/Tests/WebsiteTests.cs
+++ b/src/IIS.Tests/Tests/WebsiteTests.cs
@@ -169,30 +169,5 @@ namespace Cake.IIS.Tests
             Assert.NotNull(site);
             Assert.True(site.State == ObjectState.Stopped);
         }
-
-        [Theory]
-        [InlineData(true,false,true)]
-        [InlineData(false,true,false)]
-        public void Should_Set_Authentication(bool anon,bool basic,bool win)
-        {
-            // Arrange
-            var websiteName = "HumanTorch";
-            CakeHelper.DeleteWebsite(websiteName);
-            var settings = CakeHelper.GetWebsiteSettings(websiteName);
-            settings.Authentication = CakeHelper.GetAuthenticationSettings(anon, basic, win);
-
-            //Act
-            CakeHelper.CreateWebsite(settings);
-            CakeHelper.StartWebsite(websiteName);
-
-            //Assert
-            var authentication = CakeHelper.ReadAuthenticationSettings(websiteName);
-            Assert.Equal(anon, authentication.EnableAnonymousAuthentication);
-            Assert.Equal(basic, authentication.EnableBasicAuthentication);
-            Assert.Equal(win, authentication.EnableWindowsAuthentication);
-
-            CakeHelper.DeleteWebsite(websiteName);
-
-        }
     }
 }

--- a/src/IIS.Tests/Tests/WebsiteTests.cs
+++ b/src/IIS.Tests/Tests/WebsiteTests.cs
@@ -169,5 +169,30 @@ namespace Cake.IIS.Tests
             Assert.NotNull(site);
             Assert.True(site.State == ObjectState.Stopped);
         }
+
+        [Theory]
+        [InlineData(true,false,true)]
+        [InlineData(false,true,false)]
+        public void Should_Set_Authentication(bool anon,bool basic,bool win)
+        {
+            // Arrange
+            var websiteName = "HumanTorch";
+            CakeHelper.DeleteWebsite(websiteName);
+            var settings = CakeHelper.GetWebsiteSettings(websiteName);
+            settings.Authentication = CakeHelper.GetAuthenticationSettings(anon, basic, win);
+
+            //Act
+            CakeHelper.CreateWebsite(settings);
+            CakeHelper.StartWebsite(websiteName);
+
+            //Assert
+            var authentication = CakeHelper.ReadAuthenticationSettings(websiteName);
+            Assert.Equal(anon, authentication.EnableAnonymousAuthentication);
+            Assert.Equal(basic, authentication.EnableBasicAuthentication);
+            Assert.Equal(win, authentication.EnableWindowsAuthentication);
+
+            CakeHelper.DeleteWebsite(websiteName);
+
+        }
     }
 }

--- a/src/IIS.Tests/Utils/CakeHelper.cs
+++ b/src/IIS.Tests/Utils/CakeHelper.cs
@@ -1,4 +1,4 @@
-﻿#region Using Statements
+#region Using Statements
 using System;
 using System.Linq;
 using System.IO;
@@ -128,6 +128,18 @@ namespace Cake.IIS.Tests
                 Servers = new string[] { "Gotham", "Metroplis" }
             };
         }
+
+        public static AuthenticationSettings GetAuthenticationSettings(bool? anonymous, bool? basic, bool? windows)
+        {
+            return new AuthenticationSettings()
+            {
+                EnableAnonymousAuthentication = anonymous,
+                EnableBasicAuthentication = basic,
+                EnableWindowsAuthentication = windows
+            };
+        }
+
+     
 
 
 
@@ -308,7 +320,35 @@ namespace Cake.IIS.Tests
             }
         }
 
+            //Authentication
+            public static AuthenticationSettings ReadAuthenticationSettings(string siteName = null, string appPath=null )
+            {
+                var location = siteName != null ? siteName + (appPath ?? "") : null;
+                var element = "system.webServer/security/authentication/{0}";
+                var anon = GetSectionElementValue<bool>(string.Format(element, "anonymousAuthentication"), "enabled", location);
+                var basic = GetSectionElementValue<bool>(string.Format(element, "basicAuthentication"), "enabled", location);
+                var windows = GetSectionElementValue<bool>(string.Format(element, "windowsAuthentication"), "enabled", location);
 
+                return  new AuthenticationSettings()
+                {
+                    EnableWindowsAuthentication = windows,
+                    EnableBasicAuthentication = basic,
+                    EnableAnonymousAuthentication = anon
+                };
+
+            }
+
+            //General
+            public static T GetSectionElementValue<T>(string elementPath, string attributeName, string location)
+            {
+                using (var serverManager = new ServerManager())
+                {
+                    var config = serverManager.GetApplicationHostConfiguration();
+                    var element = location ==null? config.GetSection(elementPath) :  config.GetSection(elementPath, location);
+                    var t = typeof(T);
+                    return (T)Convert.ChangeType( element[attributeName], t);
+                }
+            }
 
         //WebFarm
         public static void CreateWebFarm(WebFarmSettings settings)

--- a/src/IIS.Tests/Utils/CakeHelper.cs
+++ b/src/IIS.Tests/Utils/CakeHelper.cs
@@ -1,4 +1,4 @@
-#region Using Statements
+﻿#region Using Statements
 using System;
 using System.Linq;
 using System.IO;
@@ -128,18 +128,6 @@ namespace Cake.IIS.Tests
                 Servers = new string[] { "Gotham", "Metroplis" }
             };
         }
-
-        public static AuthenticationSettings GetAuthenticationSettings(bool anonymous, bool basic, bool windows)
-        {
-            return new AuthenticationSettings()
-            {
-                EnableAnonymousAuthentication = anonymous,
-                EnableBasicAuthentication = basic,
-                EnableWindowsAuthentication = windows
-            };
-        }
-
-     
 
 
 
@@ -300,34 +288,7 @@ namespace Cake.IIS.Tests
             }
         }
 
-            //Authentication
-            public static AuthenticationSettings ReadAuthenticationSettings(string websiteName)
-            {
-                var element = "system.webServer/security/authentication/{0}";
-                var anon = GetSectionElementValue<bool>(string.Format(element, "anonymousAuthentication"), "enabled", websiteName);
-                var basic = GetSectionElementValue<bool>(string.Format(element, "basicAuthentication"), "enabled", websiteName);
-                var windows = GetSectionElementValue<bool>(string.Format(element, "windowsAuthentication"), "enabled", websiteName);
 
-                return  new AuthenticationSettings()
-                {
-                    EnableWindowsAuthentication = windows,
-                    EnableBasicAuthentication = basic,
-                    EnableAnonymousAuthentication = anon
-                };
-
-            }
-
-            //General
-            public static T GetSectionElementValue<T>(string elementPath, string attributeName, string location)
-            {
-                using (var serverManager = new ServerManager())
-                {
-                    var config = serverManager.GetApplicationHostConfiguration();
-                    var element =config.GetSection(elementPath, location);
-                    var t = typeof(T);
-                    return (T)Convert.ChangeType( element[attributeName], t);
-                }
-            }
 
         //WebFarm
         public static void CreateWebFarm(WebFarmSettings settings)

--- a/src/IIS.Tests/Utils/CakeHelper.cs
+++ b/src/IIS.Tests/Utils/CakeHelper.cs
@@ -1,4 +1,4 @@
-﻿#region Using Statements
+#region Using Statements
 using System;
 using System.Linq;
 using System.IO;
@@ -128,6 +128,18 @@ namespace Cake.IIS.Tests
                 Servers = new string[] { "Gotham", "Metroplis" }
             };
         }
+
+        public static AuthenticationSettings GetAuthenticationSettings(bool anonymous, bool basic, bool windows)
+        {
+            return new AuthenticationSettings()
+            {
+                EnableAnonymousAuthentication = anonymous,
+                EnableBasicAuthentication = basic,
+                EnableWindowsAuthentication = windows
+            };
+        }
+
+     
 
 
 
@@ -288,7 +300,34 @@ namespace Cake.IIS.Tests
             }
         }
 
+            //Authentication
+            public static AuthenticationSettings ReadAuthenticationSettings(string websiteName)
+            {
+                var element = "system.webServer/security/authentication/{0}";
+                var anon = GetSectionElementValue<bool>(string.Format(element, "anonymousAuthentication"), "enabled", websiteName);
+                var basic = GetSectionElementValue<bool>(string.Format(element, "basicAuthentication"), "enabled", websiteName);
+                var windows = GetSectionElementValue<bool>(string.Format(element, "windowsAuthentication"), "enabled", websiteName);
 
+                return  new AuthenticationSettings()
+                {
+                    EnableWindowsAuthentication = windows,
+                    EnableBasicAuthentication = basic,
+                    EnableAnonymousAuthentication = anon
+                };
+
+            }
+
+            //General
+            public static T GetSectionElementValue<T>(string elementPath, string attributeName, string location)
+            {
+                using (var serverManager = new ServerManager())
+                {
+                    var config = serverManager.GetApplicationHostConfiguration();
+                    var element =config.GetSection(elementPath, location);
+                    var t = typeof(T);
+                    return (T)Convert.ChangeType( element[attributeName], t);
+                }
+            }
 
         //WebFarm
         public static void CreateWebFarm(WebFarmSettings settings)

--- a/src/IIS/Manager/Base/BaseSiteManager.cs
+++ b/src/IIS/Manager/Base/BaseSiteManager.cs
@@ -1,9 +1,8 @@
 #region Using Statements
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text.RegularExpressions;
-    using System.Threading;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 
 using Cake.Core;
 using Cake.Core.Diagnostics;
@@ -155,25 +154,40 @@ namespace Cake.IIS
             if (settings != null)
             {
                 //Authentication
-                var config = _Server.GetApplicationHostConfiguration();              
-                var sectionName = "system." + server + "/security/authentication/{0}";
-                  
+                var config = _Server.GetApplicationHostConfiguration();
+
+                var locationPath = site + appPath;
+                var authentication = config.GetSection("system." + server + "/security/authorization", locationPath);
+
+
+
                 // Anonymous Authentication
-                var anonymousAuthentication = config.GetSection(string.Format(sectionName, "anonymousAuthentication"), site);
-                anonymousAuthentication["enabled"] = settings.EnableAnonymousAuthentication;
+                var anonymousAuthentication = authentication.GetChildElement("anonymousAuthentication");
+
+                anonymousAuthentication.SetAttributeValue("enabled", settings.EnableAnonymousAuthentication);
+
                 _Log.Information("Anonymous Authentication enabled: {0}", settings.EnableAnonymousAuthentication);
 
+
+
                 // Basic Authentication
-                var basicAuthentication = config.GetSection(string.Format(sectionName, "basicAuthentication"), site);
-                basicAuthentication["enabled"] = settings.EnableBasicAuthentication;
+                var basicAuthentication = authentication.GetChildElement("basicAuthentication");
+
+                basicAuthentication.SetAttributeValue("enabled", settings.EnableBasicAuthentication);
+                basicAuthentication.SetAttributeValue("userName", settings.Username);
+                basicAuthentication.SetAttributeValue("password", settings.Password);
+
                 _Log.Information("Basic Authentication enabled: {0}", settings.EnableBasicAuthentication);
 
+
+
                 // Windows Authentication
-                var windowsAuthentication = config.GetSection(string.Format(sectionName, "windowsAuthentication"), site);
-                windowsAuthentication["enabled"] = settings.EnableWindowsAuthentication;
+                var windowsAuthentication = authentication.GetChildElement("windowsAuthentication");
+
+                windowsAuthentication.SetAttributeValue("enabled", settings.EnableWindowsAuthentication);
+
                 _Log.Information("Windows Authentication enabled: {0}", settings.EnableWindowsAuthentication);
             }
-            
         }
 
         /// <summary>

--- a/src/IIS/Manager/Base/BaseSiteManager.cs
+++ b/src/IIS/Manager/Base/BaseSiteManager.cs
@@ -1,8 +1,9 @@
 #region Using Statements
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text.RegularExpressions;
+    using System.Threading;
 
 using Cake.Core;
 using Cake.Core.Diagnostics;
@@ -154,40 +155,25 @@ namespace Cake.IIS
             if (settings != null)
             {
                 //Authentication
-                var config = _Server.GetApplicationHostConfiguration();
-
-                var locationPath = site + appPath;
-                var authentication = config.GetSection("system." + server + "/security/authorization", locationPath);
-
-
-
+                var config = _Server.GetApplicationHostConfiguration();              
+                var sectionName = "system." + server + "/security/authentication/{0}";
+                  
                 // Anonymous Authentication
-                var anonymousAuthentication = authentication.GetChildElement("anonymousAuthentication");
-
-                anonymousAuthentication.SetAttributeValue("enabled", settings.EnableAnonymousAuthentication);
-
+                var anonymousAuthentication = config.GetSection(string.Format(sectionName, "anonymousAuthentication"), site);
+                anonymousAuthentication["enabled"] = settings.EnableAnonymousAuthentication;
                 _Log.Information("Anonymous Authentication enabled: {0}", settings.EnableAnonymousAuthentication);
 
-
-
                 // Basic Authentication
-                var basicAuthentication = authentication.GetChildElement("basicAuthentication");
-
-                basicAuthentication.SetAttributeValue("enabled", settings.EnableBasicAuthentication);
-                basicAuthentication.SetAttributeValue("userName", settings.Username);
-                basicAuthentication.SetAttributeValue("password", settings.Password);
-
+                var basicAuthentication = config.GetSection(string.Format(sectionName, "basicAuthentication"), site);
+                basicAuthentication["enabled"] = settings.EnableBasicAuthentication;
                 _Log.Information("Basic Authentication enabled: {0}", settings.EnableBasicAuthentication);
 
-
-
                 // Windows Authentication
-                var windowsAuthentication = authentication.GetChildElement("windowsAuthentication");
-
-                windowsAuthentication.SetAttributeValue("enabled", settings.EnableWindowsAuthentication);
-
+                var windowsAuthentication = config.GetSection(string.Format(sectionName, "windowsAuthentication"), site);
+                windowsAuthentication["enabled"] = settings.EnableWindowsAuthentication;
                 _Log.Information("Windows Authentication enabled: {0}", settings.EnableWindowsAuthentication);
             }
+            
         }
 
         /// <summary>

--- a/src/IIS/Manager/Base/BaseSiteManager.cs
+++ b/src/IIS/Manager/Base/BaseSiteManager.cs
@@ -125,114 +125,11 @@ namespace Cake.IIS
             // Security
             var serverType = settings is WebsiteSettings ? "webServer" : "ftpServer";
             var hostConfig = GetWebConfiguration();
-            hostConfig.SetAuthentication(serverType, settings.Name, "", settings.Authentication);
-            hostConfig.SetAuthorization(serverType, settings.Name, "", settings.Authorization);
+            hostConfig.SetAuthentication(serverType, settings.Name, "", settings.Authentication,_Log);
+            hostConfig.SetAuthorization(serverType, settings.Name, "", settings.Authorization, _Log);
 
             return site;
         }
-
-        /// <summary>
-        /// Sets the authentication settings for the site
-        /// </summary>
-        /// /// <param name="server">The atype of server</param>
-        /// <param name="site">The name of the site</param>
-        /// <param name="appPath">The application path</param>
-        /// <param name="settings">The authentication settings</param>
-        protected void SetAuthentication(string server, string site, string appPath, AuthenticationSettings settings)
-        {
-            if (settings != null)
-            {
-                //Authentication
-                var config = _Server.GetApplicationHostConfiguration();              
-                var sectionName = "system." + server + "/security/authentication/{0}";
-                var location = site + appPath;
-                // Anonymous Authentication
-                if (settings.EnableAnonymousAuthentication.HasValue)
-                {
-                    var anonymousAuthentication = config.GetSection(string.Format(sectionName, "anonymousAuthentication"), location);
-                    anonymousAuthentication["enabled"] = settings.EnableAnonymousAuthentication;
-                    _Log.Information("Anonymous Authentication enabled: {0}", settings.EnableAnonymousAuthentication);
-                }
-                // Basic Authentication
-                if (settings.EnableBasicAuthentication.HasValue)
-                {
-                    var basicAuthentication = config.GetSection(string.Format(sectionName, "basicAuthentication"), location);
-                    basicAuthentication["enabled"] = settings.EnableBasicAuthentication;
-                    _Log.Information("Basic Authentication enabled: {0}", settings.EnableBasicAuthentication);
-                }
-
-                // Windows Authentication
-                if (settings.EnableWindowsAuthentication.HasValue)
-                {
-                    var windowsAuthentication = config.GetSection(string.Format(sectionName, "windowsAuthentication"), location);
-                    windowsAuthentication["enabled"] = settings.EnableWindowsAuthentication;
-                    _Log.Information("Windows Authentication enabled: {0}", settings.EnableWindowsAuthentication);
-                }
-            }
-            
-        }
-
-        /// <summary>
-        /// Sets the authorization settings for the site
-        /// </summary>
-        /// <param name="server">The atype of server</param>
-        /// <param name="site">The name of the site</param>
-        /// <param name="appPath">The application path</param>
-        /// <param name="settings">The authorization settings</param>
-        protected void SetAuthorization(string server, string site, string appPath, AuthorizationSettings settings)
-        {
-            if (settings != null)
-            {
-                //Authorization
-                var config = _Server.GetApplicationHostConfiguration();
-
-                var locationPath = site + appPath;
-                var authorization = config.GetSection("system." + server + "/security/authorization", locationPath);
-                var authCollection = authorization.GetCollection();
-
-                var addElement = authCollection.CreateElement("add");
-                addElement.SetAttributeValue("accessType", "Allow");
-
-                switch (settings.AuthorizationType)
-                {
-                    case AuthorizationType.AllUsers:
-                        addElement.SetAttributeValue("users", "*");
-                        _Log.Information("Authorization for all users.");
-                        break;
-
-                    case AuthorizationType.SpecifiedUser:
-                        addElement.SetAttributeValue("users", string.Join(", ", settings.Users));
-                        _Log.Information("Authorization resticted to specific users {0}.", settings.Users);
-                        break;
-
-                    case AuthorizationType.SpecifiedRoleOrUserGroup:
-                        addElement.SetAttributeValue("roles", string.Join(", ", settings.Roles));
-                        _Log.Information("Authorization resticted to specific roles {0}.", settings.Roles);
-                        break;
-                }
-
-
-
-                //Permissions
-                var permissions = new List<string>();
-
-                if (settings.CanRead)
-                {
-                    permissions.Add("Read");
-                }
-                if (settings.CanWrite)
-                {
-                    permissions.Add("Write");
-                }
-
-                addElement.SetAttributeValue("permissions", string.Join(", ", permissions));
-
-                authCollection.Clear();
-                authCollection.Add(addElement);
-            }
-        }
-
-
 
         /// <summary>
         /// Delets a site from IIS
@@ -520,8 +417,8 @@ namespace Cake.IIS
                 // Security
                 var serverType = "webServer";
                 var hostConfig = GetWebConfiguration();
-                hostConfig.SetAuthentication(serverType, settings.SiteName, settings.ApplicationPath, settings.Authentication);
-                hostConfig.SetAuthorization(serverType, settings.SiteName, settings.ApplicationPath, settings.Authorization);
+                hostConfig.SetAuthentication(serverType, settings.SiteName, settings.ApplicationPath, settings.Authentication,_Log);
+                hostConfig.SetAuthorization(serverType, settings.SiteName, settings.ApplicationPath, settings.Authorization,_Log);
 
                 site.Applications.Add(app);
                 _Server.CommitChanges();

--- a/src/IIS/Manager/Base/BaseSiteManager.cs
+++ b/src/IIS/Manager/Base/BaseSiteManager.cs
@@ -1,12 +1,13 @@
 #region Using Statements
+
 using System;
 using System.Linq;
 using System.Threading;
-
+using System.Collections.Generic;
 using Cake.Core;
 using Cake.Core.Diagnostics;
-
 using Microsoft.Web.Administration;
+
 #endregion
 
 
@@ -129,6 +130,109 @@ namespace Cake.IIS
 
             return site;
         }
+
+        /// <summary>
+        /// Sets the authentication settings for the site
+        /// </summary>
+        /// /// <param name="server">The atype of server</param>
+        /// <param name="site">The name of the site</param>
+        /// <param name="appPath">The application path</param>
+        /// <param name="settings">The authentication settings</param>
+        protected void SetAuthentication(string server, string site, string appPath, AuthenticationSettings settings)
+        {
+            if (settings != null)
+            {
+                //Authentication
+                var config = _Server.GetApplicationHostConfiguration();              
+                var sectionName = "system." + server + "/security/authentication/{0}";
+                var location = site + appPath;
+                // Anonymous Authentication
+                if (settings.EnableAnonymousAuthentication.HasValue)
+                {
+                    var anonymousAuthentication = config.GetSection(string.Format(sectionName, "anonymousAuthentication"), location);
+                    anonymousAuthentication["enabled"] = settings.EnableAnonymousAuthentication;
+                    _Log.Information("Anonymous Authentication enabled: {0}", settings.EnableAnonymousAuthentication);
+                }
+                // Basic Authentication
+                if (settings.EnableBasicAuthentication.HasValue)
+                {
+                    var basicAuthentication = config.GetSection(string.Format(sectionName, "basicAuthentication"), location);
+                    basicAuthentication["enabled"] = settings.EnableBasicAuthentication;
+                    _Log.Information("Basic Authentication enabled: {0}", settings.EnableBasicAuthentication);
+                }
+
+                // Windows Authentication
+                if (settings.EnableWindowsAuthentication.HasValue)
+                {
+                    var windowsAuthentication = config.GetSection(string.Format(sectionName, "windowsAuthentication"), location);
+                    windowsAuthentication["enabled"] = settings.EnableWindowsAuthentication;
+                    _Log.Information("Windows Authentication enabled: {0}", settings.EnableWindowsAuthentication);
+                }
+            }
+            
+        }
+
+        /// <summary>
+        /// Sets the authorization settings for the site
+        /// </summary>
+        /// <param name="server">The atype of server</param>
+        /// <param name="site">The name of the site</param>
+        /// <param name="appPath">The application path</param>
+        /// <param name="settings">The authorization settings</param>
+        protected void SetAuthorization(string server, string site, string appPath, AuthorizationSettings settings)
+        {
+            if (settings != null)
+            {
+                //Authorization
+                var config = _Server.GetApplicationHostConfiguration();
+
+                var locationPath = site + appPath;
+                var authorization = config.GetSection("system." + server + "/security/authorization", locationPath);
+                var authCollection = authorization.GetCollection();
+
+                var addElement = authCollection.CreateElement("add");
+                addElement.SetAttributeValue("accessType", "Allow");
+
+                switch (settings.AuthorizationType)
+                {
+                    case AuthorizationType.AllUsers:
+                        addElement.SetAttributeValue("users", "*");
+                        _Log.Information("Authorization for all users.");
+                        break;
+
+                    case AuthorizationType.SpecifiedUser:
+                        addElement.SetAttributeValue("users", string.Join(", ", settings.Users));
+                        _Log.Information("Authorization resticted to specific users {0}.", settings.Users);
+                        break;
+
+                    case AuthorizationType.SpecifiedRoleOrUserGroup:
+                        addElement.SetAttributeValue("roles", string.Join(", ", settings.Roles));
+                        _Log.Information("Authorization resticted to specific roles {0}.", settings.Roles);
+                        break;
+                }
+
+
+
+                //Permissions
+                var permissions = new List<string>();
+
+                if (settings.CanRead)
+                {
+                    permissions.Add("Read");
+                }
+                if (settings.CanWrite)
+                {
+                    permissions.Add("Write");
+                }
+
+                addElement.SetAttributeValue("permissions", string.Join(", ", permissions));
+
+                authCollection.Clear();
+                authCollection.Add(addElement);
+            }
+        }
+
+
 
         /// <summary>
         /// Delets a site from IIS

--- a/src/IIS/Settings/AuthenticationSettings.cs
+++ b/src/IIS/Settings/AuthenticationSettings.cs
@@ -9,11 +9,11 @@
 
 
 
-        public bool EnableBasicAuthentication { get; set; }
+        public bool? EnableBasicAuthentication { get; set; }
 
-        public bool EnableWindowsAuthentication { get; set; }
+        public bool? EnableWindowsAuthentication { get; set; }
 
-        public bool EnableAnonymousAuthentication { get; set; }
+        public bool? EnableAnonymousAuthentication { get; set; }
         #endregion
     }
 }

--- a/src/SolutionInfo.cs
+++ b/src/SolutionInfo.cs
@@ -5,7 +5,6 @@
 //------------------------------------------------------------------------------
 using System.Reflection;
 
-[assembly: AssemblyProduct("Cake.IIS")]
 [assembly: AssemblyVersion("0.2.3")]
 [assembly: AssemblyFileVersion("0.2.3")]
 [assembly: AssemblyInformationalVersion("0.2.3")]

--- a/src/SolutionInfo.cs
+++ b/src/SolutionInfo.cs
@@ -6,8 +6,8 @@
 using System.Reflection;
 
 [assembly: AssemblyProduct("Cake.IIS")]
-[assembly: AssemblyVersion("0.2.3")]
-[assembly: AssemblyFileVersion("0.2.3")]
-[assembly: AssemblyInformationalVersion("0.2.3")]
-[assembly: AssemblyCopyright("Copyright (c) 2015 - 2017 Sergio Silveira, Phillip Sharpe")]
+[assembly: AssemblyVersion("0.1.6")]
+[assembly: AssemblyFileVersion("0.1.6")]
+[assembly: AssemblyInformationalVersion("0.1.6")]
+[assembly: AssemblyCopyright("Copyright (c) 2015 - 2016 Sergio Silveira, Phillip Sharpe")]
 

--- a/src/SolutionInfo.cs
+++ b/src/SolutionInfo.cs
@@ -6,8 +6,8 @@
 using System.Reflection;
 
 [assembly: AssemblyProduct("Cake.IIS")]
-[assembly: AssemblyVersion("0.1.6")]
-[assembly: AssemblyFileVersion("0.1.6")]
-[assembly: AssemblyInformationalVersion("0.1.6")]
-[assembly: AssemblyCopyright("Copyright (c) 2015 - 2016 Sergio Silveira, Phillip Sharpe")]
+[assembly: AssemblyVersion("0.2.3")]
+[assembly: AssemblyFileVersion("0.2.3")]
+[assembly: AssemblyInformationalVersion("0.2.3")]
+[assembly: AssemblyCopyright("Copyright (c) 2015 - 2017 Sergio Silveira, Phillip Sharpe")]
 


### PR DESCRIPTION
When trying to set authentication, assembly would blow up complaining about missing element. I fixed the authentication part, and authorization needs fixing too, which i would do later.

There are 3 types in AuthenticationSettings: anonymous, basic and windows. You can chose which one you want to set (true/false) and leave others as null. This way code will only set the ones you are interested. This required changing types to nullable in AuthenticationSettings. 

I also removed setting username /password. It turned out the password in encrypted and it fails if you try to set to a clear text. MS recommended way is to use appcmd.exe. 

This is my first contribution, so please let me know if i made mistake somewhere. Thanks
