### PR TITLE
Set ApplicationPoolSetting properties to defaults equal to default values in IIS

### DIFF
--- a/src/Cake.IIS/Settings/ApplicationPoolSettings.cs
+++ b/src/Cake.IIS/Settings/ApplicationPoolSettings.cs
@@ -34,6 +34,9 @@ namespace Cake.IIS
             this.IdleTimeout = TimeSpan.MinValue;
             this.ShutdownTimeLimit = TimeSpan.MinValue;
             this.StartupTimeLimit = TimeSpan.MinValue;
+            this.LoadUserProfile = true;
+            this.PingingEnabled = true;
+            this.MaxProcesses = 1;
         }
         #endregion
 


### PR DESCRIPTION
This fixes issue [issue 37](https://github.com/SharpeRAD/Cake.IIS/issues/37)