### PR TITLE
Fix for Physical Path of Application not saving while VirtualDirectory is other than "/'

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,6 @@ Task("Application-Create")
         SiteName = "Default Website",
 
         ApplicationPath = "/NestedApp",
-		VirtualDirectory = "/NestedApp",
         PhysicalDirectory = "C:/Apps/KillerApp/"
     });
 });
@@ -202,7 +201,6 @@ Task("Application-Remove")
         SiteName = "Default Website",
 
         ApplicationPath = "/NestedApp",
-		VirtualDirectory = "/NestedApp",
         PhysicalDirectory = "C:/Apps/KillerApp/"
     });
 });

--- a/src/Cake.IIS.Tests/Utils/CakeHelper.cs
+++ b/src/Cake.IIS.Tests/Utils/CakeHelper.cs
@@ -145,7 +145,6 @@ namespace Cake.IIS.Tests
             {
                 ApplicationPath = "/Test",
                 ApplicationPool = CakeHelper.GetAppPoolSettings().Name,
-                VirtualDirectory = "/",
                 PhysicalDirectory = "./Test/App/",
                 SiteName = name,
             };

--- a/src/Cake.IIS/Manager/Base/BaseSiteManager.cs
+++ b/src/Cake.IIS/Manager/Base/BaseSiteManager.cs
@@ -414,7 +414,8 @@ namespace Cake.IIS
 
                 //Get Directory
                 VirtualDirectory vDir = app.VirtualDirectories.CreateElement();
-                vDir.Path = settings.VirtualDirectory;
+                // While creating application only ApplicationPath is used by IIS, so we leave default one here.
+                vDir.Path = "/";
                 vDir.PhysicalPath = this.GetPhysicalDirectory(settings);
 
                 app.VirtualDirectories.Add(vDir);

--- a/src/Cake.IIS/Settings/ApplicationSettings.cs
+++ b/src/Cake.IIS/Settings/ApplicationSettings.cs
@@ -34,10 +34,6 @@ namespace Cake.IIS
 
         public string ApplicationPool { get; set; }
 
-
-
-        public string VirtualDirectory { get; set; }
-
         public DirectoryPath WorkingDirectory { get; set; }
 
         public DirectoryPath PhysicalDirectory { get; set; }


### PR DESCRIPTION
Fixed issue #52 - During creating new Application Physical Path was not saved if VirtualDirectory provided in parameter was other than `/`