### PR TITLE
Add Server Name Indication (SNI) option for bindings

### DIFF
--- a/src/Cake.IIS/Bindings/BindingSettings.cs
+++ b/src/Cake.IIS/Bindings/BindingSettings.cs
@@ -70,7 +70,15 @@ namespace Cake.IIS
         /// Returns <see cref="BindingProtocol"/> which will be used to determine IIS binding type.
         /// </returns>
         public BindingProtocol BindingProtocol { get; set; }
-        
+
+
+        /// <summary>
+        /// Gets or sets whether or not this binding requires Server Name Indication (SNI).
+        /// </summary>
+        /// <remarks>
+        /// This setting only has an effect on HTTPS bindings.
+        /// </remarks>
+        public bool RequireServerNameIndication { get; set; }
 
 
         /// <summary>

--- a/src/Cake.IIS/Extensions/BindingExtensions.cs
+++ b/src/Cake.IIS/Extensions/BindingExtensions.cs
@@ -64,5 +64,17 @@
             binding.CertificateHash = certificateHash;
             return binding;
         }
+
+        /// <summary>
+        /// Specifies whether or not Server Name Indication (SNI) is required.
+        /// </summary>
+        /// <param name="binding">The binding.</param>
+        /// <param name="requireServerNameIndication">Whether or not Server Name Indication should be required</param>
+        /// <returns>The same <see cref="BindingSettings"/> instance so that multiple calls can be chained.</returns>
+        public static BindingSettings RequireServerNameIndication(this BindingSettings binding, bool requireServerNameIndication)
+        {
+            binding.RequireServerNameIndication = requireServerNameIndication;
+            return binding;
+        }
     }
 }

--- a/src/Cake.IIS/Manager/Base/BaseSiteManager.cs
+++ b/src/Cake.IIS/Manager/Base/BaseSiteManager.cs
@@ -124,6 +124,14 @@ namespace Cake.IIS
                 binding.CertificateStoreName = settings.Binding.CertificateStoreName;
             }
 
+            if (settings.Binding.RequireServerNameIndication)
+            {
+                if (!string.Equals(settings.Binding.BindingProtocol.ToString(), BindingProtocol.Https.ToString(), StringComparison.Ordinal))
+                    throw new Exception("Require Server Name Indication (SNI) is only applicable for HTTPS bindings");
+
+                binding.SslFlags |= SslFlags.Sni;
+            }
+
             site.Bindings.Add(binding);
 
             site.ServerAutoStart = settings.ServerAutoStart;
@@ -292,6 +300,14 @@ namespace Cake.IIS
                 if (!String.IsNullOrEmpty(settings.CertificateStoreName))
                 {
                     newBinding.CertificateStoreName = settings.CertificateStoreName;
+                }
+
+                if (settings.RequireServerNameIndication)
+                {
+                    if (!string.Equals(settings.BindingProtocol.ToString(), BindingProtocol.Https.ToString(), StringComparison.Ordinal))
+                        throw new Exception("Require Server Name Indication (SNI) is only applicable for HTTPS bindings");
+
+                    newBinding.SslFlags |= SslFlags.Sni;
                 }
 
                 site.Bindings.Add(newBinding);


### PR DESCRIPTION
HTTPS bindings has the option to require Server Name Indication (SNI).
This feature enables the configuration of this setting through Cake.ISS.