### PR TITLE
Fix logging for system's default app pools

### DIFF
--- a/src/Cake.IIS/Manager/Types/ApplicationPoolManager.cs
+++ b/src/Cake.IIS/Manager/Types/ApplicationPoolManager.cs
@@ -377,10 +377,10 @@ namespace Cake.IIS
         {
             if (ApplicationPoolBlackList.Contains(name))
             {
+                _Log.Information("Application pool '{0}' is system's default.", name);
                 return true;
             }
 
-            _Log.Information("Application pool '{0}' is system's default.", name);
             return false;
         }
         #endregion


### PR DESCRIPTION
Shouldn't the `"Application pool '{0}' is system's default."` be logged if the app pool is in `ApplicationPoolBlackList` (instead of being logged otherwise)?